### PR TITLE
DEVOFF-74 move jest config, add missing tests for coverage

### DIFF
--- a/.github/workflows/test-globalid-connect-node.yml
+++ b/.github/workflows/test-globalid-connect-node.yml
@@ -42,4 +42,5 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm run test:e2e
+      - run: npm run test:cov
       

--- a/globalid-connect/node/jest.config.ts
+++ b/globalid-connect/node/jest.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from '@jest/types';
+
+const config: Config.InitialOptions = {
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100
+    },
+    'src/{**/*.module.ts,main.ts}': {
+      branches: 0,
+      functions: 0,
+      lines: 0,
+      statements: 0
+    }
+  },
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testEnvironment: 'node',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest'
+  },
+  verbose: true
+};
+
+export default config;

--- a/globalid-connect/node/package.json
+++ b/globalid-connect/node/package.json
@@ -68,22 +68,5 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/globalid-connect/node/src/app.controller.spec.ts
+++ b/globalid-connect/node/src/app.controller.spec.ts
@@ -1,0 +1,21 @@
+import { createMock } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AppController } from './app.controller';
+
+describe('AppController', () => {
+  let controller: AppController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({ controllers: [AppController] })
+      .useMocker(createMock)
+      .compile();
+
+    controller = module.get<AppController>(AppController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+    expect(controller.index()).toBeFalsy();
+  });
+});

--- a/globalid-connect/node/src/verifications/verifications.controller.spec.ts
+++ b/globalid-connect/node/src/verifications/verifications.controller.spec.ts
@@ -1,10 +1,12 @@
 import { createMock } from '@golevelup/ts-jest';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { VerificationsController } from './verifications.controller';
 
 describe('VerificationsController', () => {
   let controller: VerificationsController;
+  let configService: ConfigService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({ controllers: [VerificationsController] })
@@ -12,9 +14,51 @@ describe('VerificationsController', () => {
       .compile();
 
     controller = module.get<VerificationsController>(VerificationsController);
+    configService = module.get<ConfigService>(ConfigService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('index', () => {
+    it('should return Connect URLs', async () => {
+      const attestationsConnectUrl = 'https://connect.global.id/attestations';
+      const identityConnectUrl = 'https://connect.global.id/identity';
+      const piiConnectUrl = 'https://connect.global.id/pii';
+      const configServiceSpy = jest.spyOn(configService, 'get')
+        .mockImplementation(key => {
+          switch (key) {
+            case 'ATTESTATIONS_CONNECT_URL':
+              return attestationsConnectUrl
+            case 'IDENTITY_CONNECT_URL':
+              return identityConnectUrl;
+            case 'PII_CONNECT_URL':
+              return piiConnectUrl;
+            default:
+              break;
+          }
+        })
+
+      const result = controller.index();
+
+      expect(result).toMatchObject({
+        connectUrls: [
+          {
+            href: attestationsConnectUrl,
+            label: expect.any(String)
+          },
+          {
+            href: identityConnectUrl,
+            label: expect.any(String)
+          },
+          {
+            href: expect.stringContaining(piiConnectUrl),
+            label: expect.any(String)
+          }
+        ]
+      });
+      expect(configServiceSpy).toHaveBeenCalledTimes(3);
+    });
   });
 });


### PR DESCRIPTION
* Move jest config to `jest.config.ts`
* Added simple tests for app.controller and verifications.controller to improve coverage.